### PR TITLE
Fix loopback partitions unavailable in docker environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Source for qemu-user-static >7.0
-FROM public.ecr.aws/ubuntu/ubuntu:lunar as qemu_binaries
+FROM public.ecr.aws/ubuntu/ubuntu:jammy as qemu_binaries
 
 # hadolint ignore=DL3008
 RUN apt-get update -qq \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Source for qemu-user-static >7.0
-FROM public.ecr.aws/ubuntu/ubuntu:jammy as qemu_binaries
+FROM public.ecr.aws/ubuntu/ubuntu:noble as qemu_binaries
 
 # hadolint ignore=DL3008
 RUN apt-get update -qq \
@@ -43,13 +43,14 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then PACKER_ARCH="arm64"; else PACKER_ARCH
 # COMPRESS WITH UPX
 RUN upx-ucl --lzma /build/packer-builder-arm /bin/packer
 
-FROM public.ecr.aws/lts/ubuntu:jammy
+FROM public.ecr.aws/lts/ubuntu:noble
 
 # hadolint ignore=DL3008
 RUN apt-get update -qq \
  && apt-get install -qqy --no-install-recommends \
   ca-certificates \
   dosfstools \
+  e2fsprogs \
   fdisk \
   gdisk \
   kpartx \


### PR DESCRIPTION
By using kpartx on the mapped loopback device, it is possible to detect the partitions from inside the docker environment.
This way, it is not necessary anymore to mount the /dev volume of the host to the docker container.
Also, it is possible to run inside CI using DinD.