### PR TITLE
Fix naming of SHA256SUMS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ archives:
     name_template: '{{ .ProjectName }}_v{{ .Version }}_x{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 
 checksum:
-  name_template: '{{ .ProjectName }}_v{{ .Version }}_x{{ .Env.API_VERSION }}_SHA256SUMS'
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 
 signs:


### PR DESCRIPTION
This commit corrects the name of the `SHA256SUMS` file so that `packer plugin install` works correctly.

## Problem

This plugin fails to install when executing `packer plugin install` or when referencing the plugin inside of a Packer template.

<details>
<summary>Installation via CLI</summary>

```shell
$ packer plugin install github.com/mkaczanowski/builder-arm v1.1.6
2 errors occurred:
	* could not get sha256 checksum file for github.com/mkaczanowski/builder-arm version 1.1.6. Is the file present on the release and correctly named ? GET https://github.com/mkaczanowski/packer-plugin-builder-arm/releases/download/v1.1.6/packer-plugin-builder-arm_v1.1.6_SHA256SUMS: 404  []
	* could not install any compatible version of plugin "github.com/mkaczanowski/builder-arm"
```
</details>

<details>
<summary>Installation via Packer template</summary>

```hcl
# test-template.pkr.hcl
packer {
  required_plugins {
    arm = {
      version = ">=v1.1.6"
      source  = "github.com/mkaczanowski/builder-arm"
    }
  }
}
```

```shell
$ docker run \
  --rm \
  --volume /dev:/dev \
  --volume $PWD:/build \
  --privileged  \
  mkaczanowski/packer-plugin-builder-arm:1.1.6 init test-template.pkr.hcl
uname -a: Linux 0ed88cfd61df 7.0.12-linuxkit #1 SMP PREEMPT Fri Aug 14 16:27:59 UTC 2026 aarch64 aarch64 aarch64 GNU/Linux
Register qemu-x86_64
Register qemu-arm
2026/08/31 02:39:42 [INFO] Packer version: 1.15.4 [go1.25.11 linux arm64]
2026/08/31 02:39:42 [INFO] PACKER_CONFIG env var not set; checking the default config file path
2026/08/31 02:39:42 [INFO] PACKER_CONFIG env var set; attempting to open config file: /root/.packerconfig
2026/08/31 02:39:42 [WARN] Config file doesn't exist: /root/.packerconfig
2026/08/31 02:39:42 [INFO] Setting cache directory: /build/.packer_cache
e: Running in background, not using a TTY
Successfully installed plugin github.com/mkaczanowski/arm from /bin/packer-plugin-builder-arm to /build/.packer_plugins/github.com/mkaczanowski/arm/packer-plugin-arm_v1.1.0_x5.0_linux_arm64
2026/08/31 02:39:42 [INFO] (telemetry) Finalizing.
2026/08/31 02:39:43 waiting for all plugin processes to complete...
running /bin/packer init test-template.pkr.hcl
2026/08/31 02:39:45 [INFO] Packer version: 1.15.4 [go1.25.11 linux arm64]
2026/08/31 02:39:45 [INFO] PACKER_CONFIG env var not set; checking the default config file path
2026/08/31 02:39:45 [INFO] PACKER_CONFIG env var set; attempting to open config file: /root/.packerconfig
2026/08/31 02:39:45 [WARN] Config file doesn't exist: /root/.packerconfig
2026/08/31 02:39:45 [INFO] Setting cache directory: /build/.packer_cache
e: Running in background, not using a TTY
2026/08/31 02:39:45 [TRACE] init: plugingetter.ListInstallationsOptions{PluginDirectory:"/build/.packer_plugins", BinaryInstallationOptions:plugingetter.BinaryInstallationOptions{APIVersionMajor:"5", APIVersionMinor:"0", OS:"linux", ARCH:"arm64", Ext:"", Checksummers:[]plugingetter.Checksummer{plugingetter.Checksummer{Type:"sha256", Hash:(*sha256.Digest)(0x40000c6280)}}, ReleasesOnly:true}}
2026/08/31 02:39:45 [TRACE] listing potential installations for "github.com/mkaczanowski/builder-arm" that match ">=v1.1.6". plugingetter.ListInstallationsOptions{PluginDirectory:"/build/.packer_plugins", BinaryInstallationOptions:plugingetter.BinaryInstallationOptions{APIVersionMajor:"5", APIVersionMinor:"0", OS:"linux", ARCH:"arm64", Ext:"", Checksummers:[]plugingetter.Checksummer{plugingetter.Checksummer{Type:"sha256", Hash:(*sha256.Digest)(0x40000c6280)}}, ReleasesOnly:true}}
2026/08/31 02:39:45 [TRACE] Getting releases of github.com/mkaczanowski/builder-arm plugin from releases.hashicorp.com
2026/08/31 02:39:46 [ERROR] Got error while trying getting data from releases.hashicorp.com, <nil>
2026/08/31 02:39:46 [TRACE] Getting releases of github.com/mkaczanowski/builder-arm plugin from github.com
2026/08/31 02:39:46 [WARNING] github-getter: no GitHub token set, if you intend to install plugins often, please set the PACKER_GITHUB_API_TOKEN env var
2026/08/31 02:39:46 [DEBUG] github-getter: getting "https://api.github.com/repos/mkaczanowski/packer-plugin-builder-arm/git/matching-refs/tags"
2026/08/31 02:39:46 [DEBUG] will try to install: [1.1.6]
2026/08/31 02:39:46 [TRACE] fetching checksums file for the "1.1.6" version of the github.com/mkaczanowski/builder-arm plugin in "/build/.packer_plugins/github.com/mkaczanowski/builder-arm"...
2026/08/31 02:39:46 [TRACE] Getting sha256 of github.com/mkaczanowski/builder-arm plugin from github.com
2026/08/31 02:39:46 [DEBUG] github-getter: getting "https://github.com/mkaczanowski/packer-plugin-builder-arm/releases/download/v1.1.6/packer-plugin-builder-arm_v1.1.6_SHA256SUMS"
2026/08/31 02:39:46 [TRACE] failed requesting: *github.ErrorResponse. GET https://github.com/mkaczanowski/packer-plugin-builder-arm/releases/download/v1.1.6/packer-plugin-builder-arm_v1.1.6_SHA256SUMS: 404  []
2026/08/31 02:39:46 [TRACE] could not get sha256 checksum file for github.com/mkaczanowski/builder-arm version 1.1.6. Is the file present on the release and correctly named ? GET https://github.com/mkaczanowski/packer-plugin-builder-arm/releases/download/v1.1.6/packer-plugin-builder-arm_v1.1.6_SHA256SUMS: 404  []
	* could not get sha256 checksum file for github.com/mkaczanowski/builder-arm version 1.1.6. Is the file present on the release and correctly named ? GET https://github.com/mkaczanowski/packer-plugin-builder-arm/releases/download/v1.1.6/packer-plugin-builder-arm_v1.1.6_SHA256SUMS: 404  []
	* could not install any compatible version of plugin "github.com/mkaczanowski/builder-arm"

Failed getting the "github.com/mkaczanowski/builder-arm" plugin:
2 errors occurred:
	* could not get sha256 checksum file for github.com/mkaczanowski/builder-arm version 1.1.6. Is the file present on the release and correctly named ? GET https://github.com/mkaczanowski/packer-plugin-builder-arm/releases/download/v1.1.6/packer-plugin-builder-arm_v1.1.6_SHA256SUMS: 404  []
	* could not install any compatible version of plugin "github.com/mkaczanowski/builder-arm"


2026/08/31 02:39:46 [INFO] (telemetry) Finalizing.
2026/08/31 02:39:46 waiting for all plugin processes to complete...
```

</details>

## Solution

When downloading the plugin from GitHub, Packer's `github` getter plugin expects the file to be in the following format.

```text
packer-plugin-{plugin.name}_{plugin.version}_SHA256SUMS
```

The following files confirm this.

* [hashicorp/packer/packer/plugin-getter/plugins.go#L572-L581](https://github.com/hashicorp/packer/blob/9f42be3f6686a9c00b3b1325fcecbba337b8b93b/packer/plugin-getter/plugins.go#L572-L581)
* [hashicorp/packer/packer/plugin-getter/github/getter.go#L248-L250](https://github.com/hashicorp/packer/blob/eb36e3c3e48a036f3e8cc94087636ee72e1303c9/packer/plugin-getter/github/getter.go#L248-L250) (the comment is incorrect)


This PR fixes the plugin download issue by renaming the SHA256SUMS file generated by GoReleaser to match the format expected by Packer's github getter plugin, `packer-plugin-builder-arm_<version>_SHA256SUMS`.